### PR TITLE
Add props to scripts and styles components

### DIFF
--- a/packages/components/src/Scripts.tsx
+++ b/packages/components/src/Scripts.tsx
@@ -2,7 +2,23 @@ import React from 'react'
 
 import { useRootContext } from './RootContext'
 
-export const Scripts: React.FC = () => {
+export const Scripts: React.FC<Omit<
+  React.DetailedHTMLProps<
+    React.ScriptHTMLAttributes<HTMLScriptElement>,
+    HTMLScriptElement
+  >,
+  'src' | 'type' | 'async'
+>> = ({
+  nonce,
+  // @ts-ignore: You could still pass them if you're
+  // using pure JavaScript
+  src,
+  // @ts-ignore
+  type,
+  // @ts-ignore
+  async,
+  ...props
+}) => {
   const {
     matchedRoutesAssets,
     matchedRoutes,
@@ -13,6 +29,10 @@ export const Scripts: React.FC = () => {
   return (
     <>
       <script
+        // We only need to add `nonce` to script tags with
+        // inlined content, hence we don't add it to the scripts
+        // below
+        nonce={nonce}
         dangerouslySetInnerHTML={{
           __html:
             'window.__serverContext = JSON.parse(' +
@@ -31,7 +51,7 @@ export const Scripts: React.FC = () => {
         .concat(mainAssets)
         .filter((file) => file.endsWith('.js'))
         .map((scriptSource) => (
-          <script key={scriptSource} defer src={scriptSource} />
+          <script key={scriptSource} {...props} defer src={scriptSource} />
         ))}
     </>
   )

--- a/packages/components/src/Styles.tsx
+++ b/packages/components/src/Styles.tsx
@@ -2,7 +2,22 @@ import React from 'react'
 
 import { useRootContext } from './RootContext'
 
-export const Styles: React.FC = () => {
+export const Styles: React.FC<Omit<
+  React.DetailedHTMLProps<
+    React.LinkHTMLAttributes<HTMLLinkElement>,
+    HTMLLinkElement
+  >,
+  'type' | 'rel' | 'href'
+>> = ({
+  // @ts-ignore: You could still pass them if you're
+  // using pure JavaScript
+  type,
+  // @ts-ignore
+  rel,
+  // @ts-ignore
+  href,
+  ...props
+}) => {
   const { matchedRoutesAssets, mainAssets } = useRootContext()
 
   return (
@@ -11,7 +26,13 @@ export const Styles: React.FC = () => {
         .concat(mainAssets)
         .filter((file) => file.endsWith('.css'))
         .map((file) => (
-          <link key={file} rel="stylesheet" type="text/css" href={file} />
+          <link
+            key={file}
+            {...props}
+            rel="stylesheet"
+            type="text/css"
+            href={file}
+          />
         ))}
     </>
   )


### PR DESCRIPTION
## Description

If you need to pass in custom props to the `<link>` and `<script>` tags generated by `<Scripts />` and `<Styles />`, such as `nonce` to inlined script tags under CSP pages, you can do so. The only omitted props from `<Scripts />` are `defer`, `src`, `type` and `async`, and the props omitted from `<Styles />` are `rel`, `href` and `type`.
