### PR TITLE
Fix request headers passed as response in handleRequest fn

### DIFF
--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -15,10 +15,20 @@ export const createRequestHandler = (): RequestHandler => {
       ]) as Array<[string, string]>,
     })
 
-    // @ts-ignore
-    handleRequest(request, req, res)
+    const responseHeaders = new Headers(
+      Object.entries(res.getHeaders()).map(([key, value]) => [
+        key,
+        Array.isArray(value) ? value : value?.toString(),
+      ]) as Array<[string, string]>
+    )
+
+    handleRequest(request, responseHeaders)
       .then((response) => {
         res.statusCode = response.status
+
+        for (const header of Object.keys(res.getHeaders())) {
+          res.removeHeader(header)
+        }
 
         response.headers.forEach((value, key) => {
           res.setHeader(key, value)


### PR DESCRIPTION
## Description

This PR fixes the `headers` (3rd parameter of your default exported function inside `app-server.jsx`) being the _request_ headers instead of the _response_ headers as it was intended to be. This may cause some small issue if anyone was using this parameter as to get some info on the headers of the _request_, but is easily fixed by reading it from `request.headers` (the first parameter of the function) instead of `headers`.