### PR TITLE
Add support for custom headers in route modules

### DIFF
--- a/packages/casterly/server/devServer.ts
+++ b/packages/casterly/server/devServer.ts
@@ -19,7 +19,7 @@ class DevServer extends DefaultServer {
   }
 
   protected getBuildId() {
-    return Promise.resolve(undefined)
+    return Promise.resolve(null)
   }
 
   protected async handleRequest(req: Request, responseHeaders?: Headers) {

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -7,7 +7,7 @@ import * as paths from './paths'
 delete require.cache[require.resolve('./paths')]
 
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'development'
+  process.env.NODE_ENV = 'production'
 }
 
 const NODE_ENV = process.env.NODE_ENV
@@ -54,9 +54,9 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
   .map((folder) => path.resolve(appDirectory, folder))
   .join(path.delimiter)
 
-// Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
+// Grab NODE_ENV and CASTERLY_PUBLIC_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in Webpack configuration.
-const REACT_APP = /^REACT_APP_/i
+const CASTERLY_PUBLIC = /^CASTERLY_PUBLIC_/i
 
 interface Env {
   [key: string]: string
@@ -67,11 +67,11 @@ function getClientEnvironment({ isServer = false, worker = false } = {}) {
   const baseEnv: Env = {
     // Useful for determining whether we’re running in production mode.
     // Most importantly, it switches React into the correct mode.
-    NODE_ENV: process.env.NODE_ENV || 'development',
+    NODE_ENV: process.env.NODE_ENV!,
   }
 
   const raw = Object.keys(process.env)
-    .filter((key) => REACT_APP.test(key))
+    .filter((key) => CASTERLY_PUBLIC.test(key))
     .reduce((env, key) => {
       env[key] = process.env[key]!
       return env

--- a/packages/components/src/RootContext.tsx
+++ b/packages/components/src/RootContext.tsx
@@ -10,7 +10,7 @@ export type RouteObjectWithKey = RouteObject & {
 export type RouteMatchWithKey = RouteMatch & { route: RouteObjectWithKey }
 
 export interface RootContext {
-  version?: string
+  version: string | null
   routes: RouteObjectWithKey[]
   matchedRoutes: RouteMatchWithKey[]
   matchedRoutesAssets: string[]

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -1,5 +1,5 @@
 export * from './RootContext'
-export * from './Styles'
-export * from './Scripts'
-export * from './Routes'
 export { useIsRoutePending } from './RoutePendingContext'
+export * from './Routes'
+export * from './Scripts'
+export * from './Styles'


### PR DESCRIPTION
With this, you can now export a `headers` function in your route module which will set the headers in your `headers` argument inside `app-server.jsx`, like the following:

```jsx
// src/routes/MyRoute.jsx

export const headers = () => ({
  'cache-control': 'public, max-age=86400',
})

export default function MyRouteComponent = () => (
  <div>
    <p>This will only update at most once a day</p>
  </div>
)
```

```jsx
// app-server.jsx

export default function handleRequest(request, statusCode, headers, context) {
  // When answering the request for the above route:
  console.log(headers) // Headers { 'Cache-Control': 'public, max-age=86400' }
}
```