### PR TITLE
Add user configuration file

### DIFF
--- a/packages/casterly/server/defaultServer.ts
+++ b/packages/casterly/server/defaultServer.ts
@@ -199,6 +199,10 @@ class DefaultServer {
 
   protected getRoutesManifestFile = (): RoutesManifest => this._routesManifest
 
+  protected getDevServerPort(): undefined | number {
+    return undefined
+  }
+
   private getServerContextForRoute = async (url: string) => {
     const routesManifest = this.getRoutesManifestFile()
 
@@ -219,6 +223,7 @@ class DefaultServer {
 
     const serverContext: ServerContext = {
       version: await this.getBuildId(),
+      devServerPort: this.getDevServerPort(),
       routes,
       matchedRoutes: matchedRoutes.map((routeMatch) => {
         const {

--- a/packages/casterly/server/devServer.ts
+++ b/packages/casterly/server/devServer.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 
-import { constants, paths } from '@casterly/cli'
+import { config, constants, paths } from '@casterly/cli'
 // @ts-ignore
 import fetch from 'make-fetch-happen'
 
@@ -22,9 +22,16 @@ class DevServer extends DefaultServer {
     return Promise.resolve(null)
   }
 
+  protected getDevServerPort() {
+    return (
+      config.userConfig.buildServer?.port ??
+      config.defaultConfig.buildServer.port
+    )
+  }
+
   protected async handleRequest(req: Request, responseHeaders?: Headers) {
     try {
-      await fetch('http://localhost:8081/server-ready')
+      await fetch(`http://localhost:${this.getDevServerPort()}/server-ready`)
     } catch {
       return new Response("The build server isn't running.", {
         status: 500,

--- a/packages/cli/src/client/hot.js
+++ b/packages/cli/src/client/hot.js
@@ -3,15 +3,16 @@ const log = (...messages) => {
 }
 
 class HMRClient {
-  constructor() {
+  constructor(devServerPort) {
     this.es = null
     this.lastHash = null
+    this.port = devServerPort
 
     window.addEventListener('beforeunload', this.close)
   }
 
   init = () => {
-    const es = new EventSource('http://localhost:8081/__webpack-hmr')
+    const es = new EventSource(`http://localhost:${this.port}/__webpack-hmr`)
 
     this.es = es
 
@@ -112,6 +113,6 @@ class HMRClient {
   }
 }
 
-const hmrClient = new HMRClient()
+const hmrClient = new HMRClient(window.__serverContext.devServerPort)
 
 hmrClient.init()

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -5,12 +5,15 @@ import whm from 'webpack-hot-middleware'
 
 import { paths } from '..'
 import createWebpackConfig from '../config/createWebpackConfig'
+import { defaultConfig, userConfig } from '../config/userConfig'
 import { logStore } from '../output/logger'
 import { watchCompilers } from '../output/watcher'
 import fileExists from '../utils/fileExists'
 
 export default async function startWatch() {
   process.env.NODE_ENV = 'development'
+
+  const webpackConfigFn = userConfig.webpack
 
   const app = express()
 
@@ -25,11 +28,13 @@ export default async function startWatch() {
     const clientConfig = await createWebpackConfig({
       dev: true,
       isServer: false,
+      configFn: webpackConfigFn,
     })
 
     const serverConfig = await createWebpackConfig({
       dev: true,
       isServer: true,
+      configFn: webpackConfigFn,
     })
 
     const multiCompiler = webpack([clientConfig, serverConfig])
@@ -64,7 +69,9 @@ export default async function startWatch() {
     })
   })
 
-  app.listen(8081, () => {
-    logStore.setState({ port: 8081 })
+  const port = userConfig.buildServer?.port ?? defaultConfig.buildServer.port
+
+  app.listen(port, () => {
+    logStore.setState({ port })
   })
 }

--- a/packages/cli/src/config/constants.ts
+++ b/packages/cli/src/config/constants.ts
@@ -23,3 +23,4 @@ export const STATIC_ENTRYPOINTS_ROUTES_ASSETS = path.join(
 
 export const ROUTES_MANIFEST_FILE = 'routes-manifest.json'
 export const BUILD_ID_FILE = 'build-id.txt'
+export const CONFIG_FILE = 'casterly.config.js'

--- a/packages/cli/src/config/createWebpackConfig.ts
+++ b/packages/cli/src/config/createWebpackConfig.ts
@@ -41,7 +41,8 @@ import { createWorkboxPlugin } from './webpack/workbox'
 const getBaseWebpackConfig = async (
   options?: Options
 ): Promise<Configuration> => {
-  const { isServer = false, dev = false, profile = false } = options ?? {}
+  const { isServer = false, dev = false, profile = false, configFn } =
+    options ?? {}
 
   // Get environment variables to inject into our app.
   const env = getClientEnvironment({ isServer })
@@ -250,7 +251,7 @@ const getBaseWebpackConfig = async (
     paths.appBrowserEntry,
   ]
 
-  return {
+  let config: Configuration = {
     mode: webpackMode,
     name: isServer ? 'server' : 'client',
     target: isServer ? 'node' : 'web',
@@ -500,6 +501,12 @@ const getBaseWebpackConfig = async (
         }),
     ].filter(filterBoolean),
   }
+
+  if (configFn) {
+    config = configFn(config, { isServer, dev })
+  }
+
+  return config
 }
 
 export default getBaseWebpackConfig

--- a/packages/cli/src/config/paths.ts
+++ b/packages/cli/src/config/paths.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
+import { defaultConfig, userConfig } from './userConfig'
+
 const appDirectory = fs.realpathSync(process.cwd())
 const resolveApp = (relativePath: string) =>
   path.resolve(appDirectory, relativePath)
@@ -30,7 +32,9 @@ export const resolveModule = (resolveFn = resolveApp, filePath: string) => {
 export const dotenv = resolveApp('.env')
 
 export const appPath = resolveApp('.')
-export const appBuildFolder = resolveApp('.dist')
+export const appBuildFolder = resolveApp(
+  userConfig.buildFolder ?? defaultConfig.buildFolder
+)
 export const appServerBuildFolder = path.join(appBuildFolder, 'server')
 export const appPublicBuildFolder = path.join(appBuildFolder, 'public')
 export const appPublic = resolveApp('public')

--- a/packages/cli/src/config/userConfig.ts
+++ b/packages/cli/src/config/userConfig.ts
@@ -1,0 +1,72 @@
+import fs from 'fs'
+import { basename, extname, join } from 'path'
+
+import { Configuration } from 'webpack'
+
+import * as Log from '../output/log'
+import { fileExistsSync } from '../utils/fileExists'
+import { CONFIG_FILE } from './constants'
+
+type RecursiveRequired<T> = T extends (...args: infer A) => infer R
+  ? (...args: A) => R
+  : // eslint-disable-next-line @typescript-eslint/ban-types
+  T extends object
+  ? {
+      [K in keyof T]-?: RecursiveRequired<T[K]>
+    }
+  : T
+
+interface BuildServerConfig {
+  port?: number
+}
+
+export interface CasterlyConfig {
+  webpack?: (
+    config: Configuration,
+    options: { isServer: boolean; dev: boolean }
+  ) => Configuration
+  buildServer?: BuildServerConfig
+  buildFolder?: string
+}
+
+export const defaultConfig: RecursiveRequired<CasterlyConfig> = {
+  webpack: (config) => config,
+  buildServer: {
+    port: 8081,
+  },
+  buildFolder: '.dist',
+}
+
+export const loadUserConfig = (dir: string): CasterlyConfig => {
+  const filePath = join(dir, CONFIG_FILE)
+
+  if (fileExistsSync(filePath)) {
+    let userConfig = require(filePath) as CasterlyConfig
+
+    if (typeof userConfig === 'undefined') {
+      Log.warn('Nothing was exported from configuration file.')
+      userConfig = defaultConfig
+    }
+
+    return userConfig
+  }
+
+  const configFileBasename = basename(CONFIG_FILE, extname(CONFIG_FILE))
+
+  const configWithDifferentExtension = ['.tsx', '.ts', '.jsx', '.json']
+    .map((ext) => join(dir, configFileBasename + ext))
+    .map(fileExistsSync)
+    .every(Boolean)
+
+  if (configWithDifferentExtension) {
+    Log.warn(
+      `Config file with unsupported extension found. Please rename the configuration file to ${JSON.stringify(
+        CONFIG_FILE
+      )}`
+    )
+  }
+
+  return defaultConfig
+}
+
+export const userConfig = loadUserConfig(fs.realpathSync(process.cwd()))

--- a/packages/cli/src/config/webpack/types.ts
+++ b/packages/cli/src/config/webpack/types.ts
@@ -1,5 +1,8 @@
+import { CasterlyConfig } from '../userConfig'
+
 export interface Options {
   isServer?: boolean
   dev?: boolean
   profile?: boolean
+  configFn?: CasterlyConfig['webpack']
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import * as constants from './config/constants'
 import * as paths from './config/paths'
+import * as config from './config/userConfig'
 
 export * from './config/webpack/plugins/routes/utils'
 
-export { constants, paths }
+export { constants, paths, config }

--- a/packages/cli/src/utils/fileExists.ts
+++ b/packages/cli/src/utils/fileExists.ts
@@ -13,4 +13,17 @@ const fileExists = async (filePath: string) => {
   }
 }
 
+export const fileExistsSync = (filePath: string) => {
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK)
+    return true
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return false
+    }
+
+    throw err
+  }
+}
+
 export default fileExists

--- a/packages/components/src/RootBrowser.tsx
+++ b/packages/components/src/RootBrowser.tsx
@@ -176,10 +176,6 @@ const InternalRoot: React.FC<RouterProps> = ({
     }
   })
 
-  useEffect(() => {
-    delete window.__serverContext
-  }, [])
-
   const [stateLocation, setStateLocation] = useState(location)
   const [routePending, setRoutePending] = useState(false)
 

--- a/packages/components/src/RootContext.tsx
+++ b/packages/components/src/RootContext.tsx
@@ -15,6 +15,7 @@ export interface RootContext {
   matchedRoutes: RouteMatchWithKey[]
   matchedRoutesAssets: string[]
   mainAssets: string[]
+  devServerPort?: number
 }
 
 const ctx = React.createContext<RootContext | null>(null)

--- a/packages/components/src/Scripts.tsx
+++ b/packages/components/src/Scripts.tsx
@@ -24,6 +24,7 @@ export const Scripts: React.FC<Omit<
     matchedRoutes,
     mainAssets,
     version,
+    devServerPort,
   } = useRootContext()
 
   return (
@@ -42,6 +43,7 @@ export const Scripts: React.FC<Omit<
                 matchedRoutesAssets,
                 matchedRoutes,
                 mainAssets,
+                devServerPort,
               })
             ) +
             ')',


### PR DESCRIPTION
Resolves #362.

This PR adds support for a config file named `casterly.config.js` in the root folder of your Casterly project. The config file can configure the following aspects of Casterly:

```js
module.exports = {
  /**
   * Here you can modify the webpack configuration as you'd like to
   * fit your project needs. You MUST return the config object, or the
   * build will fail.
   */
  webpack(config, { isServer, dev }) {
    config.plugins.push(new MyCustomPlugin())

    return config
  },
  buildServer: {
    /**
     * Configures the port for which the build server (the one started
     * with `casterly watch`) will listen to.
     */
    port: 8080,
  },
  /**
   * Configures the destination folder for the build assets both under
   * development and for production.
   */
  buildFolder: 'build'
}
```
