### PR TITLE
Prefix framework routes with /_casterly path

### DIFF
--- a/packages/casterly/server/defaultServer.ts
+++ b/packages/casterly/server/defaultServer.ts
@@ -96,22 +96,8 @@ class DefaultServer {
           }
         },
       }),
-      matchRoute<{ path: string }>({
-        route: '/static/:path*',
-        fn: async (req, _, url) => {
-          try {
-            return await serveStatic(
-              req,
-              path.join(paths.appBuildFolder, url.pathname!),
-              !this.dev
-            )
-          } catch {
-            return new Response(null, { status: 404 })
-          }
-        },
-      }),
       matchRoute({
-        route: '/__route-manifest',
+        route: '/_casterly/route-manifest',
         fn: async (req, __, url) => {
           const query = url.query as { path?: string }
 
@@ -174,6 +160,26 @@ class DefaultServer {
             status,
             headers,
           })
+        },
+      }),
+      matchRoute<{ filePath: string }>({
+        route: '/_casterly/static/:filePath*',
+        fn: async (req, { filePath }) => {
+          try {
+            return await serveStatic(
+              req,
+              path.join(paths.appBuildFolder, 'static', ...filePath),
+              !this.dev
+            )
+          } catch {
+            return new Response(null, { status: 404 })
+          }
+        },
+      }),
+      matchRoute<{ filePath: string }>({
+        route: '/_casterly/:path*',
+        fn: async () => {
+          return new Response(null, { status: 404 })
         },
       }),
     ]

--- a/packages/cli/src/client/hot.js
+++ b/packages/cli/src/client/hot.js
@@ -12,7 +12,9 @@ class HMRClient {
   }
 
   init = () => {
-    const es = new EventSource(`http://localhost:${this.port}/__webpack-hmr`)
+    const es = new EventSource(
+      `http://localhost:${this.port}/_casterly/__webpack-hmr`
+    )
 
     this.es = es
 

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -41,7 +41,9 @@ export default async function startWatch() {
 
     const [clientCompiler, serverCompiler] = multiCompiler.compilers
 
-    app.use(whm(clientCompiler, { path: '/__webpack-hmr', log: false }))
+    app.use(
+      whm(clientCompiler, { path: '/_casterly/__webpack-hmr', log: false })
+    )
 
     const useTypescript = await fileExists(paths.appTsConfig)
 

--- a/packages/cli/src/config/createWebpackConfig.ts
+++ b/packages/cli/src/config/createWebpackConfig.ts
@@ -268,7 +268,7 @@ const getBaseWebpackConfig = async (
       ignored: ['**/.git/**', '**/node_modules/**', '**/.dist/**'],
     },
     output: {
-      publicPath: '/',
+      publicPath: '/_casterly/',
       path: outputPath,
       filename: isServer
         ? '[name].js'
@@ -475,7 +475,7 @@ const getBaseWebpackConfig = async (
         new ForkTsCheckerPlugin({
           typescript: {
             typescriptPath,
-            mode: 'write-references',
+            mode: 'readonly',
             diagnosticOptions: {
               syntactic: true,
             },

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -79,10 +79,11 @@ function getClientEnvironment({ isServer = false, worker = false } = {}) {
 
   // Stringify all values so we can feed into Webpack DefinePlugin
   const stringified = {
-    'process.env': Object.keys(raw).reduce<Env>((env, key) => {
-      env[key] = JSON.stringify(raw[key])
+    ...Object.keys(raw).reduce<Env>((env, key) => {
+      env['process.env.' + key] = JSON.stringify(raw[key])
       return env
     }, {}),
+    'process.env.ASSET_PATH': '/_casterly/',
     'process.browser': JSON.stringify(!isServer),
     // Allow browser-only and server-only code to be eliminated
     'typeof window': JSON.stringify(

--- a/packages/components/src/RootBrowser.tsx
+++ b/packages/components/src/RootBrowser.tsx
@@ -23,6 +23,8 @@ declare global {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   function __webpack_require__(assetPath: string): any
+
+  const __webpack_public_path__: string
 }
 
 const parseRouteMatch = (
@@ -77,14 +79,19 @@ const mergeRoutes = (
 }
 
 const addScript = (scriptAsset: string) => {
-  if (document.querySelector(`script[src="${scriptAsset}"]`)) {
+  const url =
+    __webpack_public_path__ +
+    // remove leading slash
+    scriptAsset.slice(1)
+
+  if (document.querySelector(`script[src="${url}"]`)) {
     return Promise.resolve()
   }
 
   const script = document.createElement('script')
 
   return new Promise((resolve, reject) => {
-    script.src = scriptAsset
+    script.src = url
     script.defer = true
     script.onload = resolve
     script.onerror = reject
@@ -94,14 +101,19 @@ const addScript = (scriptAsset: string) => {
 }
 
 const addStylesheet = (styleAsset: string) => {
-  if (document.querySelector(`link[href="${styleAsset}"]`)) {
+  const url =
+    __webpack_public_path__ +
+    // remove leading slash
+    styleAsset.slice(1)
+
+  if (document.querySelector(`link[href="${url}"]`)) {
     return Promise.resolve()
   }
 
   const link = document.createElement('link')
 
   return new Promise((resolve, reject) => {
-    link.href = styleAsset
+    link.href = url
     link.type = 'text/css'
     link.rel = 'stylesheet'
     link.onload = resolve
@@ -113,7 +125,7 @@ const addStylesheet = (styleAsset: string) => {
 
 const fetchRouteData = async (path: string, version: string | null) => {
   const res = await fetch(
-    `/__route-manifest?${new URLSearchParams({
+    `/_casterly/route-manifest?${new URLSearchParams({
       path,
       v: version ?? '',
     })}`

--- a/packages/components/src/Scripts.tsx
+++ b/packages/components/src/Scripts.tsx
@@ -55,7 +55,12 @@ export const Scripts: React.FC<
         .concat(mainAssets)
         .filter((file) => file.endsWith('.js'))
         .map((scriptSource) => (
-          <script key={scriptSource} {...props} defer src={scriptSource} />
+          <script
+            key={scriptSource}
+            {...props}
+            defer
+            src={`/_casterly${scriptSource}`}
+          />
         ))}
     </>
   )

--- a/packages/components/src/Styles.tsx
+++ b/packages/components/src/Styles.tsx
@@ -33,7 +33,7 @@ export const Styles: React.FC<
             {...props}
             rel="stylesheet"
             type="text/css"
-            href={file}
+            href={`/_casterly${file}`}
           />
         ))}
     </>


### PR DESCRIPTION
This would allow for an easier CDN configuration, where you'd only need one "rule" to target all of Casterly's routes (using this `/_casterly` prefix).
