### PR TITLE
Remove user config object from default entrypoint of utils package

### DIFF
--- a/packages/casterly/server/devServer.ts
+++ b/packages/casterly/server/devServer.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 
-import { config, constants, paths } from '@casterly/utils'
+import { constants, paths } from '@casterly/utils'
+import * as config from '@casterly/utils/config'
 // @ts-ignore
 import fetch from 'make-fetch-happen'
 

--- a/packages/cli/src/config/userConfig.ts
+++ b/packages/cli/src/config/userConfig.ts
@@ -1,3 +1,3 @@
-import { config } from '@casterly/utils'
+import * as config from '@casterly/utils/config'
 
 export = config

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
-import { config, constants, paths } from '@casterly/utils'
+import { constants, paths } from '@casterly/utils'
+import * as config from '@casterly/utils/config'
 
 export * from './config/webpack/plugins/routes/utils'
 

--- a/packages/utils/config.d.ts
+++ b/packages/utils/config.d.ts
@@ -1,0 +1,1 @@
+export * from './lib/userConfig'

--- a/packages/utils/config.js
+++ b/packages/utils/config.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/userConfig')

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,5 @@
 import * as constants from './constants'
 import * as paths from './paths'
-import * as config from './userConfig'
 
 export * from './fileExists'
-export { constants, paths, config }
+export { constants, paths }


### PR DESCRIPTION
This was causing an error in production because the default server was importing the utils entrypoint package, which triggered the load for the user config (which can contain imports for development-only dependencies).
