### PR TITLE
Move webpack config to different entrypoint than config file

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -19,6 +19,7 @@ import { checkRequiredFiles, printBuildError } from '../build/utils'
 import { BUILD_ID_FILE } from '../config/constants'
 import getBaseWebpackConfig from '../config/createWebpackConfig'
 import paths from '../config/paths'
+import config from '../config/userConfig'
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -35,9 +36,15 @@ async function build(
 ) {
   console.log('Creating an optimized production build...')
 
+  const webpackConfigFn = config.loadWebpackConfig()
+
   const compiler = webpack([
-    await getBaseWebpackConfig({ profile }),
-    await getBaseWebpackConfig({ isServer: true, profile }),
+    await getBaseWebpackConfig({ profile, configFn: webpackConfigFn }),
+    await getBaseWebpackConfig({
+      isServer: true,
+      profile,
+      configFn: webpackConfigFn,
+    }),
   ])
 
   const run = util.promisify(compiler.run)

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -6,14 +6,14 @@ import whm from 'webpack-hot-middleware'
 
 import { paths } from '..'
 import createWebpackConfig from '../config/createWebpackConfig'
-import { defaultConfig, userConfig } from '../config/userConfig'
+import config from '../config/userConfig'
 import { logStore } from '../output/logger'
 import { watchCompilers } from '../output/watcher'
 
 export default async function startWatch() {
   process.env.NODE_ENV = 'development'
 
-  const webpackConfigFn = userConfig.webpack
+  const webpackConfigFn = config.loadWebpackConfig()
 
   const app = express()
 
@@ -71,7 +71,8 @@ export default async function startWatch() {
     })
   })
 
-  const port = userConfig.buildServer?.port ?? defaultConfig.buildServer.port
+  const port =
+    config.userConfig.buildServer?.port ?? config.defaultConfig.buildServer.port
 
   app.listen(port, () => {
     logStore.setState({ port })

--- a/packages/cli/src/config/createWebpackConfig.ts
+++ b/packages/cli/src/config/createWebpackConfig.ts
@@ -11,6 +11,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import semver from 'semver'
 import webpack, { Compiler, Configuration } from 'webpack'
 
+import { warn } from '../output/log'
 import { getDependencyVersion } from '../utils/dependencies'
 import { filterBoolean } from '../utils/filterBoolean'
 import resolveRequest from '../utils/resolveRequest'
@@ -499,7 +500,19 @@ const getBaseWebpackConfig = async (
   }
 
   if (configFn) {
-    config = configFn(config, { isServer, dev })
+    const userConfig = configFn(config, { isServer, dev })
+
+    if (typeof userConfig !== 'object' || 'then' in userConfig) {
+      warn(
+        `Webpack config function expected to return an object, but instead received "${typeof userConfig}".${
+          typeof userConfig === 'object' && 'then' in userConfig
+            ? ' Did you accidentally return a Promise?'
+            : ''
+        }`
+      )
+    } else {
+      config = userConfig
+    }
   }
 
   return config

--- a/packages/cli/src/config/userConfig.ts
+++ b/packages/cli/src/config/userConfig.ts
@@ -1,3 +1,25 @@
-import * as config from '@casterly/utils/config'
+import fs from 'fs'
+import { join } from 'path'
 
-export = config
+import { constants, fileExistsSync } from '@casterly/utils'
+import * as config from '@casterly/utils/config'
+import { Configuration } from 'webpack'
+
+type WebpackConfigFn = (
+  config: Configuration,
+  options: { dev: boolean; isServer: boolean }
+) => Configuration | undefined
+
+const loadWebpackConfig = () => {
+  const dir = fs.realpathSync(process.cwd())
+
+  const file = join(dir, constants.WEBPACK_CONFIG_FILE)
+
+  if (!fileExistsSync(file)) {
+    return
+  }
+
+  return require(file) as WebpackConfigFn
+}
+
+export = { loadWebpackConfig, ...config }

--- a/packages/cli/src/config/webpack/types.ts
+++ b/packages/cli/src/config/webpack/types.ts
@@ -1,8 +1,8 @@
-import { CasterlyConfig } from '../userConfig'
+import config from '../userConfig'
 
 export interface Options {
   isServer?: boolean
   dev?: boolean
   profile?: boolean
-  configFn?: CasterlyConfig['webpack']
+  configFn?: ReturnType<typeof config.loadWebpackConfig>
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.10",
-    "rimraf": "^3.0.0",
-    "webpack": "^5.10.0"
+    "rimraf": "^3.0.0"
   }
 }

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -24,3 +24,4 @@ export const STATIC_ENTRYPOINTS_ROUTES_ASSETS = path.join(
 export const ROUTES_MANIFEST_FILE = 'routes-manifest.json'
 export const BUILD_ID_FILE = 'build-id.txt'
 export const CONFIG_FILE = 'casterly.config.js'
+export const WEBPACK_CONFIG_FILE = 'webpack.config.js'

--- a/packages/utils/src/userConfig.ts
+++ b/packages/utils/src/userConfig.ts
@@ -1,8 +1,6 @@
 import fs from 'fs'
 import { basename, extname, join } from 'path'
 
-import type { Configuration } from 'webpack'
-
 import { CONFIG_FILE } from './constants'
 import { fileExistsSync } from './fileExists'
 
@@ -20,16 +18,11 @@ interface BuildServerConfig {
 }
 
 export interface CasterlyConfig {
-  webpack?: (
-    config: Configuration,
-    options: { isServer: boolean; dev: boolean }
-  ) => Configuration
   buildServer?: BuildServerConfig
   buildFolder?: string
 }
 
 export const defaultConfig: RecursiveRequired<CasterlyConfig> = {
-  webpack: (config) => config,
   buildServer: {
     port: 8081,
   },


### PR DESCRIPTION
I'm currently running into one issue in production, because I install only the production dependencies (`devDependencies` are not included) and I keep getting an error when Casterly loads my config file because of the webpack require. So I'm moving the webpack configuration to a different filename (`webpack.config.js`) so it is safe to require the config file in prod.

This PR also fixes the webpack config fn not used in the build command.

So, you'd need to remove the `webpack` function from the `casterly.config.js` file and move it to the default export of `webpack.config.js`

Before:

```js
// casterly.config.js
module.exports = {
  webpack(config) {
    // add custom plugins
    return config
  }
}
```

After:

```js
// webpack.config.js
module.exports = (config) => {
  // add custom plugins
  return config
}
```