### PR TITLE
Add babel config function

### DIFF
--- a/packages/casterly/src/commands/build.ts
+++ b/packages/casterly/src/commands/build.ts
@@ -37,13 +37,19 @@ async function build(
   console.log('Creating an optimized production build...')
 
   const webpackConfigFn = config.loadWebpackConfig()
+  const babelConfigFn = config.loadBabelConfig()
 
   const compiler = webpack([
-    await getBaseWebpackConfig({ profile, configFn: webpackConfigFn }),
+    await getBaseWebpackConfig({
+      profile,
+      configFn: webpackConfigFn,
+      babelConfigFn,
+    }),
     await getBaseWebpackConfig({
       isServer: true,
       profile,
       configFn: webpackConfigFn,
+      babelConfigFn,
     }),
   ])
 

--- a/packages/casterly/src/commands/watch.ts
+++ b/packages/casterly/src/commands/watch.ts
@@ -14,6 +14,7 @@ export default async function startWatch() {
   process.env.NODE_ENV = 'development'
 
   const webpackConfigFn = config.loadWebpackConfig()
+  const babelConfigFn = config.loadBabelConfig()
 
   const app = express()
 
@@ -29,12 +30,14 @@ export default async function startWatch() {
       dev: true,
       isServer: false,
       configFn: webpackConfigFn,
+      babelConfigFn,
     })
 
     const serverConfig = await createWebpackConfig({
       dev: true,
       isServer: true,
       configFn: webpackConfigFn,
+      babelConfigFn,
     })
 
     const multiCompiler = webpack([clientConfig, serverConfig])

--- a/packages/casterly/src/config/userConfig.ts
+++ b/packages/casterly/src/config/userConfig.ts
@@ -10,6 +10,11 @@ type WebpackConfigFn = (
   options: { dev: boolean; isServer: boolean }
 ) => Configuration | undefined
 
+type BabelConfigFn = (
+  babelConfig: Record<string, unknown>,
+  options: { dev: boolean; isServer: boolean }
+) => Record<string, unknown> | undefined
+
 const loadWebpackConfig = () => {
   const dir = fs.realpathSync(process.cwd())
 
@@ -22,4 +27,16 @@ const loadWebpackConfig = () => {
   return require(file) as WebpackConfigFn
 }
 
-export = { loadWebpackConfig, ...config }
+const loadBabelConfig = () => {
+  const dir = fs.realpathSync(process.cwd())
+
+  const file = join(dir, constants.WEBPACK_CONFIG_FILE)
+
+  if (!fileExistsSync(file)) {
+    return
+  }
+
+  return require(file).babelConfig as BabelConfigFn | undefined
+}
+
+export = { loadWebpackConfig, loadBabelConfig, ...config }

--- a/packages/casterly/src/config/webpack/types.ts
+++ b/packages/casterly/src/config/webpack/types.ts
@@ -5,4 +5,5 @@ export interface Options {
   dev?: boolean
   profile?: boolean
   configFn?: ReturnType<typeof config.loadWebpackConfig>
+  babelConfigFn?: ReturnType<typeof config.loadBabelConfig>
 }


### PR DESCRIPTION
This PR adds support for babel-specific config function, if you want to extend the base babel config used in webpack.

It was already possible to extend the babel config before, using the webpack config file, but it was really error-prone, and dependended on the internal structure of our webpack config, like:

```js
// BEFORE
// webpack.config.js

module.exports = (config) => {
  config.module.rules[0].oneOf[2].options.plugins.push(
    'my-babel-plugin'
  )

  return config
}
```

So now, you can export a `babelConfig` function in your `webpack.config.js` file, which can extend the base babel config in a more structured way.

```js
// AFTER
// webpack.config.js

module.exports = (config) => {
  // ... webpack-specific configuration
}

exports.babelConfig = (babelConfig) => ({
  ...babelConfig,
  plugins: [
    ...babelConfig.plugins,
    'my-babel-plugin',
  ],
})
```
