### PR TITLE
Skip compiling CSS in routes manifest child compiler

### DIFF
--- a/packages/casterly/src/config/createWebpackConfig.ts
+++ b/packages/casterly/src/config/createWebpackConfig.ts
@@ -30,7 +30,9 @@ import paths from './paths'
 import userConfig from './userConfig'
 import { createOptimizationConfig } from './webpack/optimization'
 import SSRImportPlugin from './webpack/plugins/SSRImportPlugin'
-import RoutesManifestPlugin from './webpack/plugins/routes/RoutesManifestPlugin'
+import RoutesManifestPlugin, {
+  CHILD_COMPILER_NAME,
+} from './webpack/plugins/routes/RoutesManifestPlugin'
 import {
   cssGlobalRegex,
   cssRegex,
@@ -71,6 +73,11 @@ const loadPostcssPlugins = () => {
 
   return postcssRc.plugins
 }
+
+const not = <T>(fn: (...args: T[]) => boolean) => (...args: T[]) => !fn(...args)
+
+const isRouteManifestChildCompiler = (name: string) =>
+  name === CHILD_COMPILER_NAME
 
 const getBaseWebpackConfig = async (
   options?: Options
@@ -118,30 +125,41 @@ const getBaseWebpackConfig = async (
     {
       test: cssGlobalRegex,
       use: cssConfig,
+      compiler: not(isRouteManifestChildCompiler),
     },
     {
       test: cssRegex,
       exclude: [cssGlobalRegex, /node_modules/],
       use: cssModuleConfig,
+      compiler: not(isRouteManifestChildCompiler),
     },
     {
       test: cssRegex,
       include: [{ not: [paths.appSrc] }],
       use: cssConfig,
+      compiler: not(isRouteManifestChildCompiler),
     },
     {
       test: sassGlobalRegex,
       use: sassConfig,
+      compiler: not(isRouteManifestChildCompiler),
     },
     {
       test: sassRegex,
       exclude: [sassGlobalRegex, /node_modules/],
       use: sassModuleConfig,
+      compiler: not(isRouteManifestChildCompiler),
     },
     {
       test: sassRegex,
       include: [{ not: [paths.appSrc] }],
       use: sassConfig,
+      compiler: not(isRouteManifestChildCompiler),
+    },
+    {
+      test: [sassRegex, cssRegex],
+      use: ['ignore-loader'],
+      compiler: isRouteManifestChildCompiler,
     },
   ]
 

--- a/packages/casterly/src/config/webpack/plugins/routes/RoutesManifestPlugin.ts
+++ b/packages/casterly/src/config/webpack/plugins/routes/RoutesManifestPlugin.ts
@@ -34,6 +34,8 @@ const countNumberOfRoutes = (routes: RouteAssetComponent[]): number => {
   }, 0)
 }
 
+export const CHILD_COMPILER_NAME = 'routeAssets'
+
 export default class RoutesManifestPlugin {
   private routeModuleIdMap: Map<string, string | number> = new Map()
 
@@ -55,7 +57,7 @@ export default class RoutesManifestPlugin {
   public apply(compiler: Compiler) {
     compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, cb) => {
       const childCompiler = compilation.createChildCompiler(
-        'routeAssets',
+        CHILD_COMPILER_NAME,
         compiler.options.output,
         []
       )
@@ -82,7 +84,7 @@ export default class RoutesManifestPlugin {
           return cb(childCompilation.errors[0])
         }
 
-        cb()
+        childCompiler.close(cb)
       })
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,7 +2750,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^4.6.0":
+"@typescript-eslint/eslint-plugin@^4.6.0", "@typescript-eslint/eslint-plugin@~4.8.0":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz#cf9102ec800391caa574f589ffe0623cca1d9308"
   integrity sha512-gQ06QLV5l1DtvYtqOyFLXD9PdcILYqlrJj2l+CGDlPtmgLUzc1GpqciJFIRvyfvgLALpnxYINFuw+n9AZhPBKQ==


### PR DESCRIPTION
This PR is an attempt to fix the following error:

```
Failed to compile.

No module factory available for dependency type: CssDependency
```
