### PR TITLE
Remove file-loader "catch-all"

### DIFF
--- a/packages/casterly/package.json
+++ b/packages/casterly/package.json
@@ -61,7 +61,6 @@
     "dotenv-expand": "^5.1.0",
     "express": "^4.17.1",
     "fibers": "^5.0.0",
-    "file-loader": "^6.2.0",
     "filesize": "^6.1.0",
     "fork-ts-checker-webpack-plugin": "^6.0.5",
     "fs-extra": "^9.0.1",

--- a/packages/casterly/src/config/createWebpackConfig.ts
+++ b/packages/casterly/src/config/createWebpackConfig.ts
@@ -20,7 +20,6 @@ import {
   STATIC_ASSETS_PATH,
   STATIC_CHUNKS_PATH,
   STATIC_ENTRYPOINTS_ROUTES,
-  STATIC_MEDIA_PATH,
   STATIC_RUNTIME_HOT,
   STATIC_RUNTIME_MAIN,
   STATIC_WEBPACK_PATH,
@@ -406,6 +405,7 @@ const getBaseWebpackConfig = async (
         },
         {
           test: /\.(js|mjs)$/,
+          include: /node_modules/,
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           loader: require.resolve('babel-loader'),
           options: {
@@ -455,21 +455,6 @@ const getBaseWebpackConfig = async (
           },
         },
         ...cssRules,
-        // "file" loader makes sure those assets get served by build server.
-        // When you `import` an asset, you get its (virtual) filename.
-        // In production, they would get copied to the `build` folder.
-        {
-          exclude: [
-            /\.(js|mjs|jsx|ts|tsx)$/,
-            /\.(scss|sass|css)$/,
-            /\.html$/,
-            /\.json$/,
-          ],
-          loader: require.resolve('file-loader'),
-          options: {
-            name: `${STATIC_MEDIA_PATH}/[name].[hash:8].[ext]`,
-          },
-        },
       ],
     },
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,14 +5715,6 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 filesize@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.1.0.tgz#e81bdaa780e2451d714d71c0d7a4f3238d37ad00"


### PR DESCRIPTION
This loader was being used before as a "catch-all" loader due to the `oneOf` rule, but since we are not using it anymore it may now be doing more harm than what it is worth, although you can easily add this loader back (using the `webpack.config.js` file).
