### PR TITLE
Add manual parsing of PostCSS config values

### DIFF
--- a/packages/casterly/src/config/webpack/styles.ts
+++ b/packages/casterly/src/config/webpack/styles.ts
@@ -38,6 +38,7 @@ export const getStyleLoaders = ({
           inline: false,
           annotate: false,
         },
+        config: false,
         plugins: postcssPlugins,
       },
     },

--- a/packages/casterly/src/output/log.ts
+++ b/packages/casterly/src/output/log.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk'
 
 const prefixes = {
-  wait: chalk`{dim casterly} {magenta wait}:`,
+  wait: chalk`{dim casterly} {magenta wait}: `,
   error: chalk`{dim casterly} {red error}:`,
-  warn: chalk`{dim casterly} {yellow warn}:`,
+  warn: chalk`{dim casterly} {yellow warn}: `,
   ready: chalk`{dim casterly} {green ready}:`,
-  info: chalk`{dim casterly} {cyan info}:`,
+  info: chalk`{dim casterly} {cyan info}: `,
 }
 
 export function wait(...message: any[]) {


### PR DESCRIPTION
This should remove the errors from `postcss-loader` when symlinking this library in development.
