### PR TITLE
Add filename of changed file and build duration time in logs

### DIFF
--- a/packages/casterly/src/output/logger.ts
+++ b/packages/casterly/src/output/logger.ts
@@ -5,12 +5,13 @@ import type { WebpackError } from '../build/utils'
 import * as Log from './log'
 
 type WebpackState =
-  | { loading: true }
+  | { loading: true; fileName?: string }
   | {
       loading: false
       typeChecking: boolean
       errors: WebpackError[] | null
       warnings: WebpackError[] | null
+      buildDuration: number
     }
 
 export type LoggerStoreStatus =
@@ -58,7 +59,11 @@ logStore.subscribe((state) => {
   }
 
   if (state.loading === true) {
-    Log.wait('compiling...')
+    if (state.fileName) {
+      Log.wait(`${state.fileName} changed, compiling...`)
+    } else {
+      Log.wait('compiling...')
+    }
     return
   }
 
@@ -75,5 +80,5 @@ logStore.subscribe((state) => {
     return
   }
 
-  Log.ready('compiled successfully')
+  Log.ready(`compiled successfully in ${state.buildDuration} seconds`)
 })


### PR DESCRIPTION
This PR changes the logs to contain the filename of the changed file (the one that triggered the recompilation), and the total duration of the build, as you can see below

<img width="662" alt="image" src="https://user-images.githubusercontent.com/10223856/116635568-808cbd00-a935-11eb-9982-b38f930bbdb1.png">