### PR TITLE
Add test for app-server as async module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -39,5 +39,18 @@ module.exports = {
       globalTeardown:
         '<rootDir>/test/integration/typescript/jest/global-teardown.js',
     },
+    {
+      displayName: 'async-modules-app',
+      testMatch: [
+        '<rootDir>/test/integration/async-modules/**/*.test.[jt]s?(x)',
+      ],
+      setupFilesAfterEnv: [
+        '<rootDir>/test/integration/async-modules/jest/setup.js',
+      ],
+      globalSetup:
+        '<rootDir>/test/integration/async-modules/jest/global-setup.js',
+      globalTeardown:
+        '<rootDir>/test/integration/async-modules/jest/global-teardown.js',
+    },
   ],
 }

--- a/packages/core/src/server/defaultServer.ts
+++ b/packages/core/src/server/defaultServer.ts
@@ -292,15 +292,11 @@ class DefaultServer {
       path.join(paths.appServerBuildFolder, STATIC_RUNTIME_MAIN)
     )
 
-    if (
-      typeof serverEntrypointModule.default === 'object' &&
-      serverEntrypointModule.default.default
-    ) {
-      // TypeScript will wrap the above import call with an __importStar
-      // function, which will make the default exports the reference to the
-      // actual module, so we must interop twice to get the actual
-      // implementation
-      serverEntrypointModule = serverEntrypointModule.default
+    if (typeof serverEntrypointModule.default?.then === 'function') {
+      // Async modules exports a promise instead of an object, so we must await
+      // the default export to get the actual module object
+      // https://webpack.js.org/blog/2020-10-10-webpack-5-release/#async-modules
+      serverEntrypointModule = await serverEntrypointModule.default
     }
 
     return serverEntrypointModule

--- a/test/integration/async-modules/jest/global-setup.js
+++ b/test/integration/async-modules/jest/global-setup.js
@@ -1,0 +1,12 @@
+const { resolve } = require('path')
+
+const { startServer } = require('../../../test-utils')
+
+const port = 3004
+
+module.exports = async () => {
+  global.testAsyncModulesServer = await startServer(
+    resolve(__dirname, '..'),
+    port
+  )
+}

--- a/test/integration/async-modules/jest/global-teardown.js
+++ b/test/integration/async-modules/jest/global-teardown.js
@@ -1,0 +1,5 @@
+const { killServer } = require('../../../test-utils')
+
+module.exports = async () => {
+  await killServer(global.testAsyncModulesServer)
+}

--- a/test/integration/async-modules/jest/setup.js
+++ b/test/integration/async-modules/jest/setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(15000)

--- a/test/integration/async-modules/src/app-browser.jsx
+++ b/test/integration/async-modules/src/app-browser.jsx
@@ -1,0 +1,11 @@
+import { Routes } from '@casterly/components'
+import { RootBrowser } from '@casterly/components/browser'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+ReactDOM.hydrate(
+  <RootBrowser>
+    <Routes />
+  </RootBrowser>,
+  document.getElementById('root')
+)

--- a/test/integration/async-modules/src/app-server.jsx
+++ b/test/integration/async-modules/src/app-server.jsx
@@ -1,0 +1,44 @@
+import { Routes, Scripts, Styles } from '@casterly/components'
+import { RootServer } from '@casterly/components/server'
+import contentType from 'async-dep'
+import React from 'react'
+import { renderToNodeStream } from 'react-dom/server'
+
+const Document = () => {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <Styles />
+      </head>
+      <body>
+        <div id="root">
+          <Routes />
+        </div>
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+
+export default async function (request, statusCode, headers, context) {
+  const content = renderToNodeStream(
+    <RootServer context={context} url={request.url}>
+      <Document />
+    </RootServer>
+  )
+
+  content.unshift('<!doctype html>')
+
+  return new Response(content, {
+    status: statusCode,
+    headers: {
+      ...Object.fromEntries(headers),
+      'content-type': contentType,
+    },
+  })
+}

--- a/test/integration/async-modules/src/index.jsx
+++ b/test/integration/async-modules/src/index.jsx
@@ -1,0 +1,3 @@
+export default function IndexPage() {
+  return <h1>Hello world from async module!</h1>
+}

--- a/test/integration/async-modules/src/routes.js
+++ b/test/integration/async-modules/src/routes.js
@@ -1,0 +1,6 @@
+export default [
+  {
+    path: '/',
+    component: () => import('./index'),
+  },
+]

--- a/test/integration/async-modules/test/index.test.ts
+++ b/test/integration/async-modules/test/index.test.ts
@@ -1,0 +1,28 @@
+import type { Browser, Page } from 'puppeteer'
+import puppeteer from 'puppeteer'
+
+const port = 3004
+
+describe('Hello World with async modules', () => {
+  let browser: Browser
+  let page: Page
+
+  beforeEach(async () => {
+    browser = await puppeteer.launch()
+    page = await browser.newPage()
+  })
+
+  afterEach(async () => {
+    await browser.close()
+  })
+
+  it('should render a hello world page', async () => {
+    const response = await page.goto(`http://localhost:${port}/`)
+
+    expect(response?.headers()['content-type']).toMatch('text/html')
+
+    await expect(page.content()).resolves.toMatch(
+      '<h1>Hello world from async module!</h1>'
+    )
+  })
+})

--- a/test/integration/async-modules/webpack.config.js
+++ b/test/integration/async-modules/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = (webpackConfig, { isServer }) => {
+  if (isServer) {
+    webpackConfig.externals = [
+      {
+        'async-dep': 'promise Promise.resolve("text/html")',
+      },
+      ...webpackConfig.externals,
+    ]
+  }
+  return webpackConfig
+}


### PR DESCRIPTION
Also fixes an error when the `app-server.tsx` entrypoint is an async module.